### PR TITLE
add CORS fix

### DIFF
--- a/src/main/java/com/example/loginauthapi/infra/security/SecurityConfig.java
+++ b/src/main/java/com/example/loginauthapi/infra/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -28,6 +29,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()


### PR DESCRIPTION
Olá!

Da forma como está, o frontend apresenta erro na comunicação com o backend e não realiza nenhuma das operações.
Até onde observei, quando o frontend chama o backend, há uma requisição ao método "OPTIONS" do http e o Spring está esperando que esta requisição esteja autenticada, quando o ideal é que ele simplesmente a ignore e gerencie apenas o "GET" e "POST".
Atualmente, o navegador reclama da ausência do campo `Access-Control-Allow-Origin` no cabeçalho (mais info [aqui](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Guides/CORS/Errors/CORSMissingAllowOrigin)). A solução consiste em adicionar mais um filtro em `SecurityConfig::securityFilterChain` (`.cors(Customizer.withDefaults())`) que permite que o Spring Security ignore a checagem de autenticação em "OPTIONS" e que o  campo `Access-Control-Allow-Origin` seja adicionado ao cabeçalho.